### PR TITLE
No pdf/epub on readthedocs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: '3'
-formats:
-  - pdf
-  - epub
 sphinx:
   fail_on_warning: true
 version: 2


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--77.org.readthedocs.build/en/77/

<!-- readthedocs-preview serious-scaffold-python end -->