### PR TITLE
ci: Fix prefix for Dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 updates:
   - commit-message:
-      prefix: build(requirements)
+      prefix: build(actions)
     directory: /
     package-ecosystem: github-actions
     schedule:
       interval: weekly
   - commit-message:
-      prefix: build(actions)
+      prefix: build(requirements)
     directory: /
     package-ecosystem: pip
     schedule:

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/dependabot.yml
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/dependabot.yml
@@ -1,12 +1,12 @@
 updates:
   - commit-message:
-      prefix: build(requirements)
+      prefix: build(actions)
     directory: /
     package-ecosystem: github-actions
     schedule:
       interval: weekly
   - commit-message:
-      prefix: build(actions)
+      prefix: build(requirements)
     directory: /
     package-ecosystem: pip
     schedule:


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--123.org.readthedocs.build/en/123/

<!-- readthedocs-preview serious-scaffold-python end -->