### PR TITLE
ci(dependabot): Add groups for pip dependabot updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
   - commit-message:
       prefix: build(requirements)
     directory: /
+    groups:
+      dev:
+        dependency-type: development
+      prod:
+        dependency-type: production
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/dependabot.yml
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/dependabot.yml
@@ -8,6 +8,11 @@ updates:
   - commit-message:
       prefix: build(requirements)
     directory: /
+    groups:
+      dev:
+        dependency-type: development
+      prod:
+        dependency-type: production
     package-ecosystem: pip
     schedule:
       interval: weekly


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--129.org.readthedocs.build/en/129/

<!-- readthedocs-preview serious-scaffold-python end -->