### PR TITLE
docs: Use markdown for all documentation.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
     "interruptible",
     "isort",
     "JPKXI",
+    "maxdepth",
     "modindex",
     "mypy",
     "pathjoin",

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,6 @@
+# API Reference
+
+```{toctree}
+:maxdepth: 1
+settings
+```

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,7 +1,0 @@
-API Reference
-=============
-
-.. toctree::
-   :maxdepth: 1
-
-   settings

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -1,0 +1,5 @@
+# serious_scaffold.settings
+
+```{eval-rst}
+.. automodule:: serious_scaffold.settings
+```

--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -1,4 +1,0 @@
-serious_scaffold.settings
-=========================
-
-.. automodule:: serious_scaffold.settings

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,0 +1,6 @@
+# CLI Reference
+
+```{click} serious_scaffold.cli:typer_click_object
+:prog: serious-scaffold-cli
+:nested: full
+```

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -1,6 +1,0 @@
-CLI Reference
-=============
-
-.. click:: serious_scaffold.cli:typer_click_object
-  :prog: serious-scaffold-cli
-  :nested: full

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Welcome to Serious Scaffold Python's documentation!
+# Welcome to Serious Scaffold Python's documentation
 
 ```{toctree}
 :hidden:

--- a/docs/reports/coverage/index.md
+++ b/docs/reports/coverage/index.md
@@ -1,0 +1,3 @@
+# Coverage Reports
+
+<!-- placeholder for generated coverage reports -->

--- a/docs/reports/coverage/index.rst
+++ b/docs/reports/coverage/index.rst
@@ -1,4 +1,0 @@
-Coverage Reports
-================
-
-This is a placeholder for coverage reports which supposed to be overridden.

--- a/docs/reports/index.md
+++ b/docs/reports/index.md
@@ -1,0 +1,7 @@
+# Code Quality Reports
+
+```{toctree}
+:maxdepth: 2
+mypy/index
+coverage/index
+```

--- a/docs/reports/index.rst
+++ b/docs/reports/index.rst
@@ -1,8 +1,0 @@
-Code Quality Reports
-====================
-
-.. toctree::
-   :maxdepth: 2
-
-   mypy/index
-   coverage/index

--- a/docs/reports/mypy/index.md
+++ b/docs/reports/mypy/index.md
@@ -1,0 +1,3 @@
+# MyPy Reports
+
+<!-- placeholder for generated mypy reports -->

--- a/docs/reports/mypy/index.rst
+++ b/docs/reports/mypy/index.rst
@@ -1,4 +1,0 @@
-MyPy Reports
-============
-
-This is a placeholder for mypy reports which supposed to be overridden.

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -27,6 +27,7 @@
     "interruptible",
     "isort",
     "JPKXI",
+    "maxdepth",
     "modindex",
     "mypy",
     "pathjoin",

--- a/template/docs/api/index.md.jinja
+++ b/template/docs/api/index.md.jinja
@@ -1,0 +1,6 @@
+# API Reference
+
+```{toctree}
+:maxdepth: 1
+settings
+```

--- a/template/docs/api/index.rst.jinja
+++ b/template/docs/api/index.rst.jinja
@@ -1,7 +1,0 @@
-API Reference
-=============
-
-.. toctree::
-   :maxdepth: 1
-
-   settings

--- a/template/docs/api/settings.md.jinja
+++ b/template/docs/api/settings.md.jinja
@@ -1,0 +1,5 @@
+# {{ module_name }}.settings
+
+```{eval-rst}
+.. automodule:: {{ module_name }}.settings
+```

--- a/template/docs/api/settings.rst.jinja
+++ b/template/docs/api/settings.rst.jinja
@@ -1,4 +1,0 @@
-{{ module_name }}.settings
-=========================
-
-.. automodule:: {{ module_name }}.settings

--- a/template/docs/cli/index.md.jinja
+++ b/template/docs/cli/index.md.jinja
@@ -1,0 +1,6 @@
+# CLI Reference
+
+```{click} {{ module_name }}.cli:typer_click_object
+:prog: {{ package_name }}-cli
+:nested: full
+```

--- a/template/docs/cli/index.rst.jinja
+++ b/template/docs/cli/index.rst.jinja
@@ -1,6 +1,0 @@
-CLI Reference
-=============
-
-.. click:: {{ module_name }}.cli:typer_click_object
-  :prog: {{ package_name }}-cli
-  :nested: full

--- a/template/docs/index.md.jinja
+++ b/template/docs/index.md.jinja
@@ -1,4 +1,4 @@
-# Welcome to {{ project_name }}'s documentation!
+# Welcome to {{ project_name }}'s documentation
 
 ```{toctree}
 :hidden:

--- a/template/docs/reports/coverage/index.md
+++ b/template/docs/reports/coverage/index.md
@@ -1,0 +1,3 @@
+# Coverage Reports
+
+<!-- placeholder for generated coverage reports -->

--- a/template/docs/reports/coverage/index.rst
+++ b/template/docs/reports/coverage/index.rst
@@ -1,4 +1,0 @@
-Coverage Reports
-================
-
-This is a placeholder for coverage reports which supposed to be overridden.

--- a/template/docs/reports/index.md
+++ b/template/docs/reports/index.md
@@ -1,0 +1,7 @@
+# Code Quality Reports
+
+```{toctree}
+:maxdepth: 2
+mypy/index
+coverage/index
+```

--- a/template/docs/reports/index.rst
+++ b/template/docs/reports/index.rst
@@ -1,8 +1,0 @@
-Code Quality Reports
-====================
-
-.. toctree::
-   :maxdepth: 2
-
-   mypy/index
-   coverage/index

--- a/template/docs/reports/mypy/index.md
+++ b/template/docs/reports/mypy/index.md
@@ -1,0 +1,3 @@
+# MyPy Reports
+
+<!-- placeholder for generated mypy reports -->

--- a/template/docs/reports/mypy/index.rst
+++ b/template/docs/reports/mypy/index.rst
@@ -1,4 +1,0 @@
-MyPy Reports
-============
-
-This is a placeholder for mypy reports which supposed to be overridden.


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--134.org.readthedocs.build/en/134/

<!-- readthedocs-preview serious-scaffold-python end -->