### PR TITLE
chore: Remove CHANGELOG.md from watch list of docs autobuild.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,6 @@ docs:
 # Generate documentation with auto build when changes happen.
 docs-autobuild:
 	${PIPRUN} python -m sphinx_autobuild docs ${PUBLIC_DIR} \
-		--watch CHANGELOG.md \
 		--watch README.md \
 		--watch src
 

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -126,7 +126,6 @@ docs:
 # Generate documentation with auto build when changes happen.
 docs-autobuild:
 	${PIPRUN} python -m sphinx_autobuild docs ${PUBLIC_DIR} \
-		--watch CHANGELOG.md \
 		--watch README.md \
 		--watch src
 


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--149.org.readthedocs.build/en/149/

<!-- readthedocs-preview serious-scaffold-python end -->