### PR TITLE
ci: Fix syntax error for GitHub Actions workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           path: public
   pages-deploy:
-    needs: build
+    needs: pages-build
     permissions:
       pages: write
       id-token: write

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
@@ -48,7 +48,7 @@ jobs:
         with:
           path: public
   pages-deploy:
-    needs: build
+    needs: pages-build
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--162.org.readthedocs.build/en/162/

<!-- readthedocs-preview serious-scaffold-python end -->