### PR TITLE
ci: Fix release workflow for GitHub Actions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,20 +16,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
           TWINE_USERNAME: ${{ vars.TWINE_USERNAME }}
         run: make upload
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install git-changelog using pipx
-        run: pipx install git-changelog
-      - name: Prepare release notes
-        run: git-changelog --release-notes > release-notes.md
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          body_path: release-notes.md
-          prerelease: ${{ startsWith(github.ref, 'refs/tags/v0') }}
-  pages-build:
+  pages-build-with-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,12 +30,18 @@ jobs:
       - run: env | sort
       - run: make dev-docs
       - run: make docs
+      - run: make release-notes > release-notes.md
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: release-notes.md
+          prerelease: ${{ startsWith(github.ref, 'refs/tags/v0') }}
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v2
         with:
           path: public
   pages-deploy:
-    needs: pages-build
+    needs: pages-build-with-release
     permissions:
       pages: write
       id-token: write

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,11 @@ changelog:
 		echo "Existing Changelog found at '$(CHANGELOG_URL)', download for incremental generation."; \
 		wget -q -O $(CHANGELOG_PATH) $(CHANGELOG_URL); \
 	fi
-	$(PIPRUN) git-changelog -ETrio docs/changelog.md -c conventional -s build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test
+	$(PIPRUN) git-changelog -ETrio $(CHANGELOG_PATH) -c conventional -s build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test
+
+# Generate release notes from changelog.
+release-notes:
+	$(PIPRUN) git-changelog --input $(CHANGELOG_PATH) --release-notes
 
 # Build documentation only from src.
 docs-gen:

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -143,7 +143,11 @@ changelog:
 		echo "Existing Changelog found at '$(CHANGELOG_URL)', download for incremental generation."; \
 		wget -q -O $(CHANGELOG_PATH) $(CHANGELOG_URL); \
 	fi
-	$(PIPRUN) git-changelog -ETrio docs/changelog.md -c conventional -s build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test
+	$(PIPRUN) git-changelog -ETrio $(CHANGELOG_PATH) -c conventional -s build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test
+
+# Generate release notes from changelog.
+release-notes:
+	$(PIPRUN) git-changelog --input $(CHANGELOG_PATH) --release-notes
 
 # Build documentation only from src.
 docs-gen:

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
@@ -16,20 +16,7 @@ jobs:
           TWINE_PASSWORD: {{ '${{ secrets.TWINE_PASSWORD }}' }}
           TWINE_USERNAME: {{ '${{ vars.TWINE_USERNAME }}' }}
         run: make upload
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install git-changelog using pipx
-        run: pipx install git-changelog
-      - name: Prepare release notes
-        run: git-changelog --release-notes > release-notes.md
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          body_path: release-notes.md
-          prerelease: {{ '${{ startsWith(github.ref, \'refs/tags/v0\') }}' }}
-  pages-build:
+  pages-build-with-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,12 +30,18 @@ jobs:
       - run: env | sort
       - run: make dev-docs
       - run: make docs
+      - run: make release-notes > release-notes.md
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: release-notes.md
+          prerelease: {{ '${{ startsWith(github.ref, \'refs/tags/v0\') }}' }}
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v2
         with:
           path: public
   pages-deploy:
-    needs: pages-build
+    needs: pages-build-with-release
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--163.org.readthedocs.build/en/163/

<!-- readthedocs-preview serious-scaffold-python end -->