### PR TITLE
docs: Fix rst parsing in cli reference.

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,6 +1,7 @@
 # CLI Reference
 
-```{click} serious_scaffold.cli:typer_click_object
-:prog: serious-scaffold-cli
-:nested: full
+```{eval-rst}
+.. click:: serious_scaffold.cli:typer_click_object
+  :prog: serious-scaffold-cli
+  :nested: full
 ```

--- a/template/docs/cli/index.md.jinja
+++ b/template/docs/cli/index.md.jinja
@@ -1,6 +1,7 @@
 # CLI Reference
 
-```{click} {{ module_name }}.cli:typer_click_object
-:prog: {{ package_name }}-cli
-:nested: full
+```{eval-rst}
+.. click:: {{ module_name }}.cli:typer_click_object
+  :prog: {{ package_name }}-cli
+  :nested: full
 ```


### PR DESCRIPTION


<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--205.org.readthedocs.build/en/205/

<!-- readthedocs-preview serious-scaffold-python end -->