### PR TITLE
ci(github): Set default value for TWINE_USERNAME env to '__token__'.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - env:
           TWINE_NON_INTERACTIVE: true
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: ${{ vars.TWINE_USERNAME }}
+          TWINE_USERNAME: ${{ vars.TWINE_USERNAME != '' && vars.TWINE_USERNAME || '__token__' }}
         run: make upload
   pages-build:
     runs-on: ubuntu-latest

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
@@ -15,7 +15,7 @@ jobs:
       - env:
           TWINE_NON_INTERACTIVE: true
           TWINE_PASSWORD: {{ '${{ secrets.TWINE_PASSWORD }}' }}
-          TWINE_USERNAME: {{ '${{ vars.TWINE_USERNAME }}' }}
+          TWINE_USERNAME: {{ '${{ vars.TWINE_USERNAME != \'\' && vars.TWINE_USERNAME || \'__token__\' }}' }}
         run: make upload
   pages-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
After merging this pull request, we should remove the settings for `TWINE_USERNAME` and release a new version for test.

<!-- readthedocs-preview serious-scaffold-python start -->
----
:books: Documentation preview :books:: https://serious-scaffold-python--232.org.readthedocs.build/en/232/

<!-- readthedocs-preview serious-scaffold-python end -->